### PR TITLE
untagged edit contact test now that bug is fixed. also added a wait c…

### DIFF
--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/AboutOrganisation/EditContactDetails.feature
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/AboutOrganisation/EditContactDetails.feature
@@ -35,12 +35,13 @@ Scenario: Appear on Preview
 	Then the Contact details is saved
 	When a User previews the Marketing Page
 	Then the correct contact details for the solution is displayed
+
 @BUG_3860
-@ignore
 Scenario: One contact only saves one record
 	Given the User has entered any Contact Detail	
 	And the User attempts to save 
 	Then there is 1 record in the contact table
+
 @BUG_3860
 Scenario: Two contacts saves two records
 	Given the User has entered two Contact Details	

--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/AboutOrganisation/EditContactDetails.feature.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/AboutOrganisation/EditContactDetails.feature.cs
@@ -296,15 +296,12 @@ this.ScenarioInitialize(scenarioInfo);
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("One contact only saves one record")]
         [NUnit.Framework.CategoryAttribute("BUG_3860")]
-        [NUnit.Framework.CategoryAttribute("ignore")]
         public virtual void OneContactOnlySavesOneRecord()
         {
             string[] tagsOfScenario = new string[] {
-                    "BUG_3860",
-                    "ignore"};
+                    "BUG_3860"};
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("One contact only saves one record", null, new string[] {
-                        "BUG_3860",
-                        "ignore"});
+                        "BUG_3860"});
 #line 40
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
@@ -347,7 +344,7 @@ this.ScenarioInitialize(scenarioInfo);
                     "BUG_3860"};
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("Two contacts saves two records", null, new string[] {
                         "BUG_3860"});
-#line 45
+#line 46
 this.ScenarioInitialize(scenarioInfo);
 #line hidden
             bool isScenarioIgnored = default(bool);
@@ -367,13 +364,13 @@ this.ScenarioInitialize(scenarioInfo);
             else
             {
                 this.ScenarioStart();
-#line 46
+#line 47
  testRunner.Given("the User has entered two Contact Details", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
 #line hidden
-#line 47
+#line 48
  testRunner.And("the User attempts to save", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-#line 48
+#line 49
  testRunner.Then("there are 2 records in the contact table", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line hidden
             }

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/Features/EditFeatures.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/Features/EditFeatures.cs
@@ -63,6 +63,7 @@ namespace MarketingPageAcceptanceTestsSpecflow
         [Then(@"the (.*) is saved")]
         public void ThenTheSectionIsSaved(string section)
         {
+            _test.pages.Dashboard.PageDisplayed();
             _test.pages.Dashboard.ShouldDisplaySections();
             _test.pages.Dashboard.SectionCompleteStatus(section);
         }


### PR DESCRIPTION
…heck as occasionally test fail due to 0 records in DB, assuming it's reading too fast.

I thought one of us already untagged this scenario, but i can't see anything in the git history to suggest it's been retagged through a bad merge.