### PR TITLE
Adding Mobile first tests for Native mobile section

### DIFF
--- a/src/MarketingPageAcceptanceTests.Actions/Collections/PageActionCollection.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Collections/PageActionCollection.cs
@@ -7,16 +7,27 @@ namespace MarketingPageAcceptanceTests.Actions.Collections
         public Common Common { get; set; }
         public Dashboard Dashboard { get; set; }
         public EditFeatures EditFeatures { get; set; }
-        public SolutionDescription SolutionDescription { get; internal set; }
-        public PreviewPage PreviewPage { get; internal set; }
+        public SolutionDescription SolutionDescription { get; set; }
+        public PreviewPage PreviewPage { get; set; }
         public ClientApplicationTypes ClientApplicationTypes { get; set; }
+        public BrowserBasedSections BrowserBasedSections { get; set; }
+        public NativeMobileSections NativeMobileSections { get; set; }
+        public ContactDetails ContactDetails { get; set; }
+    }
+
+    public sealed class BrowserBasedSections
+    {
         public BrowserSubDashboard BrowserSubDashboard { get; set; }
         public BrowsersSupported BrowsersSupported { get; set; }
         public PluginsOrExtensions PluginsOrExtensions { get; set; }
-        public ContactDetails ContactDetails { get; set; }
         public HardwareRequirements HardwareRequirements { get; set; }
         public ConnectivityAndResolution ConnectivityAndResolution { get; set; }
         public MobileFirst MobileFirst { get; set; }
-        public NativeMobileOperatingSystems NativeMobileOperatingSystems { get; set; }
+    }
+
+    public sealed class NativeMobileSections
+    {   
+        public NativeMobileOperatingSystems OperatingSystems { get; set; }
+        public MemoryAndStorage MemoryAndStorage { get; set; }
     }
 }

--- a/src/MarketingPageAcceptanceTests.Actions/PageActions.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/PageActions.cs
@@ -16,14 +16,21 @@ namespace MarketingPageAcceptanceTests.Actions
                 SolutionDescription = new SolutionDescription(driver),
                 PreviewPage = new PreviewPage(driver),
                 ClientApplicationTypes = new ClientApplicationTypes(driver),
-                BrowserSubDashboard = new BrowserSubDashboard(driver),
-                BrowsersSupported = new BrowsersSupported(driver),
-                PluginsOrExtensions = new PluginsOrExtensions(driver),
-                ContactDetails = new ContactDetails(driver),
-                HardwareRequirements = new HardwareRequirements(driver),
-                ConnectivityAndResolution = new ConnectivityAndResolution(driver),
-                MobileFirst = new MobileFirst(driver),
-                NativeMobileOperatingSystems = new NativeMobileOperatingSystems(driver)
+                BrowserBasedSections = new BrowserBasedSections()
+                {
+                    BrowserSubDashboard = new BrowserSubDashboard(driver),
+                    BrowsersSupported = new BrowsersSupported(driver),
+                    PluginsOrExtensions = new PluginsOrExtensions(driver),
+                    HardwareRequirements = new HardwareRequirements(driver),
+                    ConnectivityAndResolution = new ConnectivityAndResolution(driver),
+                    MobileFirst = new MobileFirst(driver),
+                },
+                NativeMobileSections = new NativeMobileSections()
+                {
+                    OperatingSystems = new NativeMobileOperatingSystems(driver),
+                    MemoryAndStorage = new MemoryAndStorage(driver)
+                },
+                ContactDetails = new ContactDetails(driver)
             };
         }
 

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/BrowsersSupported.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/BrowsersSupported.cs
@@ -14,7 +14,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
         {
             Random rand = new Random();
 
-            var checkboxes = driver.FindElements(pages.BrowsersSupported.BrowserCheckboxes);
+            var checkboxes = driver.FindElements(pages.BrowserBasedSections.BrowsersSupported.BrowserCheckboxes);
 
             // randomise order of list
             var randomised = checkboxes.Select(x => new { value = x, order = rand.Next() })
@@ -30,14 +30,14 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
         {
             Random rand = new Random();
 
-            var radioButtons = driver.FindElements(pages.BrowsersSupported.MobileResponsive);
+            var radioButtons = driver.FindElements(pages.BrowserBasedSections.BrowsersSupported.MobileResponsive);
 
             radioButtons[rand.Next(radioButtons.Count)].FindElement(By.TagName("input")).Click();
         }
 
         public void SaveAndReturn()
         {
-            driver.FindElement(pages.BrowsersSupported.SaveAndReturn).Click();
+            driver.FindElement(pages.BrowserBasedSections.BrowsersSupported.SaveAndReturn).Click();
         }
     }
 }

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/ConnectivityAndResolution.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/ConnectivityAndResolution.cs
@@ -12,13 +12,13 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
 
         public void SelectMinimumConnectionSpeed(string textValue)
         {
-            new SelectElement(driver.FindElement(pages.ConnectivityAndResolution.MinimumConnectionSpeed))
+            new SelectElement(driver.FindElement(pages.BrowserBasedSections.ConnectivityAndResolution.MinimumConnectionSpeed))
                  .SelectByText(textValue);
         }
 
         public void SelectMinimumDesktopResolution(string textValue)
         {
-            new SelectElement(driver.FindElement(pages.ConnectivityAndResolution.MinimumDesktopResolution))
+            new SelectElement(driver.FindElement(pages.BrowserBasedSections.ConnectivityAndResolution.MinimumDesktopResolution))
                 .SelectByText(textValue);
         }
     }

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/HardwareRequirements.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/HardwareRequirements.cs
@@ -13,7 +13,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
         {
             string randomText = RandomInformation.RandomString(characters);
 
-            driver.FindElement(pages.HardwareRequirements.HardwareRequirementsDescription).SendKeys(randomText);
+            driver.FindElement(pages.BrowserBasedSections.HardwareRequirements.HardwareRequirementsDescription).SendKeys(randomText);
         }
     }
 }

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/MemoryAndStorage.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/MemoryAndStorage.cs
@@ -1,0 +1,32 @@
+﻿using MarketingPageAcceptanceTests.TestData.Information;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+
+namespace MarketingPageAcceptanceTests.Actions.Pages
+{
+    public class MemoryAndStorage : PageAction
+    {
+        public MemoryAndStorage(IWebDriver driver) : base(driver)
+        {
+        }
+
+        public void SelectRequirementFromList(int index = -1)
+        {
+            var optionsCount = driver.FindElement(pages.NativeMobileSections.MemoryAndStorage.MinimumMemory).FindElements(By.TagName("option")).Count;
+            if(index == -1)
+            {
+                index = new Random().Next(1, optionsCount);
+            }
+
+            new SelectElement(driver.FindElement(pages.NativeMobileSections.MemoryAndStorage.MinimumMemory)).SelectByIndex(index);
+        }
+
+        public void TextAreaSend(int characters)
+        {
+            var text = RandomInformation.RandomString(characters);
+
+            driver.FindElement(pages.NativeMobileSections.MemoryAndStorage.DescriptionStorageRequirements).SendKeys(text);
+        }
+    }
+}

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/MobileFirst.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/MobileFirst.cs
@@ -13,7 +13,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
 
         public void SelectRadioButton(string choice)
         {
-            driver.FindElements(pages.MobileFirst.DesignedWithMobileFirstApproach)
+            driver.FindElements(pages.BrowserBasedSections.MobileFirst.DesignedWithMobileFirstApproach)
                 .Single(s => s.FindElement(By.TagName("label")).Text.Contains(choice))
                 .FindElement(By.TagName("input"))
                 .Click();

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/NativeMobileOperatingSystems.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/NativeMobileOperatingSystems.cs
@@ -12,7 +12,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
 
         public void SelectCheckboxes(int numberToSelect)
         {
-            IList<IWebElement> checkboxes = driver.FindElements(pages.SupportedOperatingSystems.OperatingSystems);
+            IList<IWebElement> checkboxes = driver.FindElements(pages.NativeMobileSections.SupportedOperatingSystems.OperatingSystems);
 
             for (int i = 0; i < numberToSelect; i++)
             {
@@ -24,7 +24,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
         {
             var text = RandomInformation.RandomString(characters);
 
-            driver.FindElement(pages.SupportedOperatingSystems.OperatingSystemsDescription).SendKeys(text);
+            driver.FindElement(pages.NativeMobileSections.SupportedOperatingSystems.OperatingSystemsDescription).SendKeys(text);
         }
     }
 }

--- a/src/MarketingPageAcceptanceTests.Actions/Pages/PluginsOrExtensions.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/PluginsOrExtensions.cs
@@ -11,7 +11,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
 
         public void SelectRadioButton(string choice)
         {
-            driver.FindElements(pages.PluginsOrExtensions.PluginsRequired)
+            driver.FindElements(pages.BrowserBasedSections.PluginsOrExtensions.PluginsRequired)
                 .Single(s => s.FindElement(By.TagName("label")).Text.Contains(choice))
                 .FindElement(By.TagName("input"))
                 .Click();
@@ -19,7 +19,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
 
         public void EnterPluginInformation(string information)
         {
-            var infoArea = driver.FindElement(pages.PluginsOrExtensions.PluginDetail);
+            var infoArea = driver.FindElement(pages.BrowserBasedSections.PluginsOrExtensions.PluginDetail);
             infoArea.SendKeys(information);
         }
     }

--- a/src/MarketingPageAcceptanceTests.Objects/Collections/PageCollection.cs
+++ b/src/MarketingPageAcceptanceTests.Objects/Collections/PageCollection.cs
@@ -11,12 +11,24 @@ namespace MarketingPageAcceptanceTests.Objects.Collections
         public PreviewPage PreviewPage { get; set; }
         public ClientApplicationTypes ClientApplicationTypes { get; set; }
         public BrowserBasedDashboard BrowserBasedDashboard { get; set; }
+        public BrowserBasedSections BrowserBasedSections { get; set; }
+        public NativeMobileSections NativeMobileSections { get; set; }
+
+        public ContactDetails ContactDetails { get; set; }
+    }
+
+    public sealed class BrowserBasedSections
+    {
         public BrowsersSupported BrowsersSupported { get; set; }
         public PluginsOrExtensions PluginsOrExtensions { get; set; }
-        public ContactDetails ContactDetails { get; set; }
         public HardwareRequirements HardwareRequirements { get; set; }
         public ConnectivityAndResolution ConnectivityAndResolution { get; set; }
         public MobileFirst MobileFirst { get; set; }
+    }
+
+    public sealed class NativeMobileSections
+    {
+
         public SupportedOperatingSystems SupportedOperatingSystems { get; set; }
     }
 }

--- a/src/MarketingPageAcceptanceTests.Objects/Collections/PageCollection.cs
+++ b/src/MarketingPageAcceptanceTests.Objects/Collections/PageCollection.cs
@@ -30,5 +30,6 @@ namespace MarketingPageAcceptanceTests.Objects.Collections
     {
 
         public SupportedOperatingSystems SupportedOperatingSystems { get; set; }
+        public MemoryAndStorage MemoryAndStorage { get; set; }
     }
 }

--- a/src/MarketingPageAcceptanceTests.Objects/PageObjects.cs
+++ b/src/MarketingPageAcceptanceTests.Objects/PageObjects.cs
@@ -15,13 +15,19 @@ namespace MarketingPageAcceptanceTests.Objects
                 PreviewPage = new Pages.PreviewPage(),
                 ClientApplicationTypes = new Pages.ClientApplicationTypes(),
                 BrowserBasedDashboard = new Pages.BrowserBasedDashboard(),
-                BrowsersSupported = new Pages.BrowsersSupported(),
-                PluginsOrExtensions = new Pages.PluginsOrExtensions(),
-                ContactDetails = new Pages.ContactDetails(),
-                HardwareRequirements = new Pages.HardwareRequirements(),
-                ConnectivityAndResolution = new Pages.ConnectivityAndResolution(),
-                MobileFirst = new Pages.MobileFirst(),
-                SupportedOperatingSystems = new Pages.SupportedOperatingSystems()
+                BrowserBasedSections = new BrowserBasedSections()
+                {
+                    BrowsersSupported = new Pages.BrowsersSupported(),
+                    PluginsOrExtensions = new Pages.PluginsOrExtensions(),                    
+                    HardwareRequirements = new Pages.HardwareRequirements(),
+                    ConnectivityAndResolution = new Pages.ConnectivityAndResolution(),
+                    MobileFirst = new Pages.MobileFirst(),
+                },
+                NativeMobileSections = new NativeMobileSections()
+                {
+                    SupportedOperatingSystems = new Pages.SupportedOperatingSystems()
+                },
+                ContactDetails = new Pages.ContactDetails()
             };
         }
 

--- a/src/MarketingPageAcceptanceTests.Objects/PageObjects.cs
+++ b/src/MarketingPageAcceptanceTests.Objects/PageObjects.cs
@@ -25,7 +25,8 @@ namespace MarketingPageAcceptanceTests.Objects
                 },
                 NativeMobileSections = new NativeMobileSections()
                 {
-                    SupportedOperatingSystems = new Pages.SupportedOperatingSystems()
+                    SupportedOperatingSystems = new Pages.SupportedOperatingSystems(),
+                    MemoryAndStorage = new Pages.MemoryAndStorage()
                 },
                 ContactDetails = new Pages.ContactDetails()
             };

--- a/src/MarketingPageAcceptanceTests.Objects/Pages/ConnectivityAndResolution.cs
+++ b/src/MarketingPageAcceptanceTests.Objects/Pages/ConnectivityAndResolution.cs
@@ -5,8 +5,8 @@ namespace MarketingPageAcceptanceTests.Objects.Pages
 {
     public sealed class ConnectivityAndResolution
     {
-        public By MinimumConnectionSpeed => CustomBy.DataTestId("combobox-options-minimum-connection-speed", "select");
+        public By MinimumConnectionSpeed => By.CssSelector("select#minimum-connection-speed");
 
-        public By MinimumDesktopResolution => CustomBy.DataTestId("combobox-options-minimum-desktop-resolution", "select");
+        public By MinimumDesktopResolution => By.CssSelector("select#minimum-desktop-resolution");
     }
 }

--- a/src/MarketingPageAcceptanceTests.Objects/Pages/MemoryAndStorage.cs
+++ b/src/MarketingPageAcceptanceTests.Objects/Pages/MemoryAndStorage.cs
@@ -1,0 +1,11 @@
+﻿using OpenQA.Selenium;
+
+namespace MarketingPageAcceptanceTests.Objects.Pages
+{
+    public class MemoryAndStorage
+    {
+        public By MinimumMemory => By.CssSelector("select#minimum-memory-requirement");
+
+        public By DescriptionStorageRequirements => By.Id("storage-requirements-description");
+    }
+}

--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/BrowserBased/ConnectivityAndResolution.feature
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/BrowserBased/ConnectivityAndResolution.feature
@@ -12,7 +12,7 @@ Scenario: Mandatory - Yes
 	Then the Connectivity and resolution section is marked as COMPLETE on the Browser Based Client Type Sub-Form
 
 Scenario:  Mandatory - No
-	Given that an answer has not been provided to the Connectivity and resolution mandatory question
+	Given that an answer has not been provided to the Connectivity and resolution mandatory question on the Browser based section
 	When the User exits the page
 	Then on the Browser based dashboard
 	And the Connectivity and resolution section is marked as INCOMPLETE on the Browser Based Client Type Sub-Form
@@ -26,7 +26,7 @@ Scenario: Appear on Preview
 	And the Connectivity and resolution details match as expected on the Preview of the Marketing Page
 
 Scenario: Mandatory Data Missing Validation
-	Given that an answer has not been provided to the Connectivity and resolution mandatory question
+	Given that an answer has not been provided to the Connectivity and resolution mandatory question on the Browser based section
 	When the User attempts to save
 	Then the Section is not saved 
 	And an indication is given to the Supplier as to why

--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/BrowserBased/PluginOrExtension.feature
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/BrowserBased/PluginOrExtension.feature
@@ -12,7 +12,7 @@ Scenario: Data Saved
 	Then the Plug-ins or extensions section is marked as COMPLETE on the Browser Based Client Type Sub-Form
 
 Scenario: Data not Saved
-	Given that an answer has not been provided to the Plug-ins or extensions mandatory question
+	Given that an answer has not been provided to the Plug-ins or extensions mandatory question on the Browser based section
 	When the User exits the page
 	Then on the Browser based dashboard
 	And the Plug-ins or extensions section is marked as INCOMPLETE on the Browser Based Client Type Sub-Form

--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/NativeMobileOrTablet/MemoryAndStorageRequirements.feature
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/NativeMobileOrTablet/MemoryAndStorageRequirements.feature
@@ -1,0 +1,51 @@
+﻿Feature: Suppliers - Edit Native Mobile or Tablet - Memory and Storage
+	As an Authority User
+	I want to edit the Memory and Storage Sub-Section
+	So that I can make sure the information is correct
+
+Background:
+	Given the user has set Native mobile or tablet application type
+
+Scenario: Mandatory - Yes
+	Given the User has entered 300 characters for Memory and storage section on Native mobile or tablet sub dashboard
+	And the User selects a memory requirement
+	When the User attempts to save
+	Then the Memory and storage section is marked as COMPLETE on the Browser Based Client Type Sub-Form
+
+Scenario: Data not Saved
+	Given that an answer has not been provided to the Memory and storage mandatory question on the Native mobile or tablet section
+	When the User exits the page
+	Then on the Native mobile or tablet dashboard
+	And the Memory and storage section is marked as INCOMPLETE on the Browser Based Client Type Sub-Form
+
+Scenario: Does not exceed maximum
+Given the User has entered 300 characters for Memory and storage section on Native mobile or tablet sub dashboard
+And the User selects a memory requirement
+When the User attempts to save 
+Then the Memory and storage is saved
+
+Scenario: Does exceed maximum
+Given the User has entered 301 characters for Memory and storage section on Native mobile or tablet sub dashboard
+And the User selects a memory requirement
+When the User attempts to save 
+Then the Section is not saved 
+And an indication is given to the Supplier as to why
+
+Scenario: Appear on Preview
+Given the User has entered 300 characters for Memory and storage section on Native mobile or tablet sub dashboard
+And the User selects a memory requirement
+And the user has saved the data
+When a User previews the Marketing Page
+Then Minimum memory requirement will be presented in Native mobile or tablet on the Preview of the Marketing Page
+And Additional storage requirements will be presented in Native mobile or tablet on the Preview of the Marketing Page
+
+Scenario: Mandatory Data Missing Validation
+Given the User has entered 300 characters for Memory and storage section on Native mobile or tablet sub dashboard
+When the User attempts to save
+Then the Section is not saved 
+And an indication is given to the Supplier as to why
+
+Scenario: Validation Error Message Anchors
+Given validation has been triggered on Native mobile or tablet section Memory and storage
+When the User selects an error link in the Error Summary
+Then the User will be navigated to the relevant section on the page

--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/NativeMobileOrTablet/MobileFirst.feature
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/NativeMobileOrTablet/MobileFirst.feature
@@ -19,12 +19,11 @@ Scenario: Data not Saved
 	Then on the Native mobile or tablet dashboard
 	And the Mobile first section is marked as INCOMPLETE on the Browser Based Client Type Sub-Form
 
-@ignore
 Scenario: Appear on Preview
 	Given that an answer is provided to the Native mobile or tablet mobile first question
 	And the user has saved the data
 	When a User previews the Marketing Page
-	Then Mobile first will be presented on the Preview of the Marketing Page
+	Then Designed with a mobile first approach will be presented in Native mobile or tablet on the Preview of the Marketing Page
 
 Scenario: Mandatory Data Missing Validation
 	Given that an answer has not been provided to the Mobile first mandatory question on the Native mobile or tablet section

--- a/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/NativeMobileOrTablet/MobileFirst.feature
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Features/ClientApplication/NativeMobileOrTablet/MobileFirst.feature
@@ -6,32 +6,33 @@
 	N.B Authority User and Supplier used interchangeably 
 
 Background:
-	Given the user has set Browser based application type
+	Given the user has set Native mobile or tablet application type
 
 Scenario: Data Saved
-	Given that an answer is provided to the Browser based mobile first question
+	Given that an answer is provided to the Native mobile or tablet mobile first question
 	When a User saves the page
 	Then the Mobile first section is marked as COMPLETE on the Browser Based Client Type Sub-Form
 
 Scenario: Data not Saved
-	Given that an answer has not been provided to the Mobile first mandatory question on the Browser based section
+	Given that an answer has not been provided to the Mobile first mandatory question on the Native mobile or tablet section
 	When the User exits the page
-	Then on the Browser based dashboard
+	Then on the Native mobile or tablet dashboard
 	And the Mobile first section is marked as INCOMPLETE on the Browser Based Client Type Sub-Form
 
+@ignore
 Scenario: Appear on Preview
-	Given that an answer is provided to the Browser based mobile first question
+	Given that an answer is provided to the Native mobile or tablet mobile first question
 	And the user has saved the data
 	When a User previews the Marketing Page
 	Then Mobile first will be presented on the Preview of the Marketing Page
 
 Scenario: Mandatory Data Missing Validation
-	Given that an answer has not been provided to the Mobile first mandatory question on the Browser based section
+	Given that an answer has not been provided to the Mobile first mandatory question on the Native mobile or tablet section
 	When the User attempts to save
 	Then the Section is not saved 
 	And an indication is given to the Supplier as to why
 
 Scenario: Validation Error Message Anchors
-	Given validation has been triggered on Browser based section Mobile first
+	Given validation has been triggered on Native mobile or tablet section Mobile first
 	When the User selects an error link in the Error Summary
 	Then the User will be navigated to the relevant section on the page

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/BrowserBased/SubDashboard.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/BrowserBased/SubDashboard.cs
@@ -49,20 +49,20 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.BrowserBa
                 "Mobile first"
             };
 
-            _test.pages.BrowserSubDashboard.GetSections().Should().BeEquivalentTo(subSectionsExpected);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.GetSections().Should().BeEquivalentTo(subSectionsExpected);
         }
 
         [Then(@"the Supplier is able to access the Browser Based Client Type Sub-Sections")]
         public void ThenTheSupplierIsAbleToAccessTheBrowserBasedClientTypeSub_Sections()
         {
-            _test.pages.BrowserSubDashboard.OpenSection("Browsers supported");
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection("Browsers supported");
             _test.pages.Common.GoBackOnePage();
         }
 
         [Then(@"the Section content validation status is displayed")]
         public void ThenTheSectionContentValidationStatusIsDisplayed()
         {
-            _test.pages.BrowserSubDashboard.SectionsHaveStatusIndicators();
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.SectionsHaveStatusIndicators();
         }
 
         [Given(@"the Browser Based Client Application Type Section requires Mandatory Data")]

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/BrowserSupported/BrowserSupported.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/BrowserSupported/BrowserSupported.cs
@@ -53,10 +53,10 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.BrowserSu
             _test.pages.Dashboard.NavigateToPreviewPage();
         }
 
-        [Then(@"on the Browser based dashboard")]
-        public void NavigateToBrowserBased()
+        [Then(@"on the (.*) dashboard")]
+        public void NavigateToSubDashboard(string subDashboard)
         {
-            _test.pages.Dashboard.NavigateToSection("Browser based", true);
+            _test.pages.Dashboard.NavigateToSection(subDashboard, true);
         }
 
         [Then(@"data will be presented on the Preview of the Marketing Page")]

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/BrowserSupported/BrowserSupported.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/BrowserSupported/BrowserSupported.cs
@@ -21,11 +21,11 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.BrowserSu
             _test.pages.ClientApplicationTypes.SelectCheckbox("Browser based");
             _test.pages.ClientApplicationTypes.SaveAndReturn();
             _test.pages.Dashboard.NavigateToSection("Browser based", true);
-            _test.pages.BrowserSubDashboard.OpenSection("Browsers supported");
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection("Browsers supported");
 
             browsersSupportedCount = new Random().Next(1, 8);
-            _test.pages.BrowsersSupported.SelectRandomCheckboxes(browsersSupportedCount);
-            _test.pages.BrowsersSupported.SelectRandomRadioButton();
+            _test.pages.BrowserBasedSections.BrowsersSupported.SelectRandomCheckboxes(browsersSupportedCount);
+            _test.pages.BrowserBasedSections.BrowsersSupported.SelectRandomRadioButton();
         }
 
         [Given(@"that data has been saved for Browsers supported")]
@@ -44,7 +44,7 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.BrowserSu
             _test.pages.ClientApplicationTypes.SaveAndReturn();
             _test.pages.Dashboard.NavigateToSection("Browser based", true);
 
-            _test.pages.BrowserSubDashboard.OpenSection("Browsers supported");
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection("Browsers supported");
         }
 
         [When(@"a User previews the Marketing Page")]

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/ConnectivityAndResolution/ConnectivityAndResolution.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/ConnectivityAndResolution/ConnectivityAndResolution.cs
@@ -17,12 +17,12 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.Connectiv
         public void GivenThatAUserHasProvidedAValueForTheConnectivityAndResolutionMandatoryInformation()
         {
             _test.pages.Dashboard.NavigateToSection("Browser based", true);
-            _test.pages.BrowserSubDashboard.OpenSection("Connectivity and resolution");
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection("Connectivity and resolution");
 
             expectedMinimumConnectionSpeed = "0.5Mbps";
             expectedMinimumDesktopResolution = "4:3 - 800 x 600";
-            _test.pages.ConnectivityAndResolution.SelectMinimumConnectionSpeed(expectedMinimumConnectionSpeed);
-            _test.pages.ConnectivityAndResolution.SelectMinimumDesktopResolution(expectedMinimumDesktopResolution);
+            _test.pages.BrowserBasedSections.ConnectivityAndResolution.SelectMinimumConnectionSpeed(expectedMinimumConnectionSpeed);
+            _test.pages.BrowserBasedSections.ConnectivityAndResolution.SelectMinimumDesktopResolution(expectedMinimumDesktopResolution);
         }
 
         [Then(@"the Connectivity and resolution details match as expected on the Preview of the Marketing Page")]

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/HardwareRequirements/HardwareRequirements.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/HardwareRequirements/HardwareRequirements.cs
@@ -19,9 +19,9 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.HardwareR
         [Given(@"a Supplier has saved any data in any field within (.*)")]
         public void GivenASupplierHasSavedAnyDataInAnyFieldWithinTheSub_Section(string sectionName)
         {
-            _test.pages.BrowserSubDashboard.OpenSection(sectionName);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(sectionName);
 
-            _test.pages.HardwareRequirements.EnterText(100);
+            _test.pages.BrowserBasedSections.HardwareRequirements.EnterText(100);
             _test.pages.Common.SectionSaveAndReturn();
         }
     }

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/MobileFirst/MobileFirst.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/MobileFirst/MobileFirst.cs
@@ -17,11 +17,11 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.MobileFir
         public void GivenThatAnAnswerIsProvidedToTheMobileFirstQuestion(string subDashboard)
         {
             _test.pages.Dashboard.NavigateToSection(subDashboard, true);
-            _test.pages.BrowserSubDashboard.OpenSection("Mobile first");
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection("Mobile first");
 
             var choice = new Random().Next() > (int.MaxValue / 2) ? "Yes" : "No";
 
-            _test.pages.MobileFirst.SelectRadioButton(choice);
+            _test.pages.BrowserBasedSections.MobileFirst.SelectRadioButton(choice);
         }
     }
 }

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/MobileFirst/MobileFirst.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/MobileFirst/MobileFirst.cs
@@ -13,10 +13,10 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.MobileFir
 
         }
 
-        [Given(@"that an answer is provided to the mobile first question")]
-        public void GivenThatAnAnswerIsProvidedToTheMobileFirstQuestion()
+        [Given(@"that an answer is provided to the (.*) mobile first question")]
+        public void GivenThatAnAnswerIsProvidedToTheMobileFirstQuestion(string subDashboard)
         {
-            _test.pages.Dashboard.NavigateToSection("Browser based", true);
+            _test.pages.Dashboard.NavigateToSection(subDashboard, true);
             _test.pages.BrowserSubDashboard.OpenSection("Mobile first");
 
             var choice = new Random().Next() > (int.MaxValue / 2) ? "Yes" : "No";

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/NativeMobileOrTablet/DisplayMarketingPageForm_NativeMobileOrTabletClientType.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/NativeMobileOrTablet/DisplayMarketingPageForm_NativeMobileOrTabletClientType.cs
@@ -41,7 +41,7 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.NativeMob
                 "Additional information"
             };
 
-            _test.pages.BrowserSubDashboard.GetSections().Should().BeEquivalentTo(subSectionsExpected);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.GetSections().Should().BeEquivalentTo(subSectionsExpected);
         }
 
     }

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/NativeMobileOrTablet/MemoryAndStorage.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/NativeMobileOrTablet/MemoryAndStorage.cs
@@ -1,0 +1,20 @@
+﻿using MarketingPageAcceptanceTestsSpecflow.Utils;
+using System;
+using TechTalk.SpecFlow;
+
+namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.NativeMobileOrTablet
+{
+    [Binding]
+    public sealed class MemoryAndStorage : TestBase
+    {
+        public MemoryAndStorage(UITest test, ScenarioContext context) : base(test, context)
+        {
+        }
+
+        [Given(@"the User selects a memory requirement")]
+        public void GivenTheUserSelectsAMemoryRequirement()
+        {
+            _test.pages.NativeMobileSections.MemoryAndStorage.SelectRequirementFromList();
+        }
+    }
+}

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/NativeMobileOrTablet/OperatingSystemsSupported.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/NativeMobileOrTablet/OperatingSystemsSupported.cs
@@ -14,9 +14,9 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.NativeMob
         public void GivenThatAUserHasProvidedAValueForTheMandatoryInformation(string section, string subDashboard)
         {
             _test.pages.Dashboard.NavigateToSection(subDashboard, true);
-            _test.pages.BrowserSubDashboard.OpenSection(section);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(section);
 
-            _test.pages.NativeMobileOperatingSystems.SelectCheckboxes(1);
+            _test.pages.NativeMobileSections.OperatingSystems.SelectCheckboxes(1);
             _test.pages.Common.SectionSaveAndReturn();
         }
 
@@ -30,18 +30,24 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.NativeMob
         public void GivenTheUserHasEnteredText(int characters, string section, string subDashboard)
         {
             _test.pages.Dashboard.NavigateToSection(subDashboard, true);
-            _test.pages.BrowserSubDashboard.OpenSection(section);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(section);
 
-            _test.pages.NativeMobileOperatingSystems.SelectCheckboxes(1);
-
-            _test.pages.NativeMobileOperatingSystems.TextAreaSendText(characters);
+            switch (section) {
+                case "Supported operating systems":                    
+                    _test.pages.NativeMobileSections.OperatingSystems.SelectCheckboxes(1);
+                    _test.pages.NativeMobileSections.OperatingSystems.TextAreaSendText(characters);
+                    break;
+                case "Memory and storage":
+                    _test.pages.NativeMobileSections.MemoryAndStorage.TextAreaSend(characters);
+                    break;
+            }
         }
 
         [Given(@"that a User has not provided any mandatory data on (.*) sub dashboard for (.*) section")]
         public void GivenThatAUserHasNotProvidedAnyMandatoryDataOnNativeMobileOrTabletSubDashboardForSupportedOperatingSystemsSection(string subDashboard, string section)
         {
             _test.pages.Dashboard.NavigateToSection(subDashboard, true);
-            _test.pages.BrowserSubDashboard.OpenSection(section);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(section);
         }
 
 

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/PluginsOrExtensions/PluginOrExtension.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/PluginsOrExtensions/PluginOrExtension.cs
@@ -16,17 +16,17 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication.PluginsOr
         public void GivenThatAnAnswerIsProvidedToThePlug_InsOrExtensionsMandatoryQuestion()
         {
             _test.pages.Dashboard.NavigateToSection("Browser based", true);
-            _test.pages.BrowserSubDashboard.OpenSection("Plug-ins or extensions");
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection("Plug-ins or extensions");
 
             var choice = new Random().Next() > (int.MaxValue / 2) ? "Yes" : "No";
 
-            _test.pages.PluginsOrExtensions.SelectRadioButton(choice);
+            _test.pages.BrowserBasedSections.PluginsOrExtensions.SelectRadioButton(choice);
         }
 
         [Given(@"the Supplier has entered Plug-in or extensions description with character count (.*)")]
         public void GivenTheSupplierHasEnteredPlug_InOrExtensionsDescriptionThatDoesExceedTheMaximumCharacterCount(int count)
         {
-            _test.pages.PluginsOrExtensions.EnterPluginInformation(RandomInformation.RandomString(count));
+            _test.pages.BrowserBasedSections.PluginsOrExtensions.EnterPluginInformation(RandomInformation.RandomString(count));
         }
     }
 }

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/SharedBrowserBasedSteps.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/SharedBrowserBasedSteps.cs
@@ -19,14 +19,14 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication
         public void GivenThatAnAnswerHasNotBeenProvidedToThePlug_InsOrExtensionsMandatoryQuestion(string section, string subDashboard)
         {
             _test.pages.Dashboard.NavigateToSection(subDashboard, true);
-            _test.pages.BrowserSubDashboard.OpenSection(section);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(section);
         }
 
         [Given(@"that a User has not provided any mandatory data for (.*)")]
         public void GivenThatAUserHasNotProvidedAnyMandatoryDataForSection(string section)
         {
             NavigateToBrowserBasedSubDashboard();
-            _test.pages.BrowserSubDashboard.OpenSection(section);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(section);
         }
 
         [Given(@"the user has saved the data")]

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/SharedBrowserBasedSteps.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/SharedBrowserBasedSteps.cs
@@ -15,10 +15,10 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication
             new SharedClientApplicationTypesSteps(_test, _context).WhenHasNavigatedToTheSpecifiedClientApplicationSub_Form("Browser based");
         }
 
-        [Given(@"that an answer has not been provided to the (.*) mandatory question")]
-        public void GivenThatAnAnswerHasNotBeenProvidedToThePlug_InsOrExtensionsMandatoryQuestion(string section)
+        [Given(@"that an answer has not been provided to the (.*) mandatory question on the (.*) section")]
+        public void GivenThatAnAnswerHasNotBeenProvidedToThePlug_InsOrExtensionsMandatoryQuestion(string section, string subDashboard)
         {
-            NavigateToBrowserBasedSubDashboard();
+            _test.pages.Dashboard.NavigateToSection(subDashboard, true);
             _test.pages.BrowserSubDashboard.OpenSection(section);
         }
 

--- a/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/SharedClientApplicationTypesSteps.cs
+++ b/src/MarketingPageAcceptanceTestsSpecflow/Steps/ClientApplication/SharedClientApplicationTypesSteps.cs
@@ -19,9 +19,9 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication
             _test.pages.ClientApplicationTypes.SaveAndReturn();
             _test.pages.Dashboard.NavigateToSection(section, true);
 
-            _test.pages.BrowserSubDashboard.OpenSection(page);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(page);
 
-            _test.pages.HardwareRequirements.EnterText(characters);
+            _test.pages.BrowserBasedSections.HardwareRequirements.EnterText(characters);
         }
 
         [Given(@"each (Browser based|Native mobile or tablet|Native desktop) Sub-Section has a content validation status")]
@@ -65,7 +65,7 @@ namespace MarketingPageAcceptanceTestsSpecflow.Steps.ClientApplication
         public void GivenValidationHasBeenTriggeredOnNativeMobileOrTabletSectionSupportedOperatingSystems(string subDashboard, string section)
         {
             _test.pages.Dashboard.NavigateToSection(subDashboard, true);
-            _test.pages.BrowserSubDashboard.OpenSection(section);
+            _test.pages.BrowserBasedSections.BrowserSubDashboard.OpenSection(section);
             _test.pages.Common.SectionSaveAndReturn();
         }
 


### PR DESCRIPTION
- [ ] Adding Mobile first tests for Native mobile and tablet application type
- [ ] Adding Memory and Storage tests
- [ ] Update Page Action collection with sub classes to organise sections of Client Application Types with similar names (i.e. moving Mobile first for Browser Based into BrowserBasedSections)