### PR TITLE
mp-test-fails-error-summary

### DIFF
--- a/src/MarketingPageAcceptanceTests.Actions/Pages/Common.cs
+++ b/src/MarketingPageAcceptanceTests.Actions/Pages/Common.cs
@@ -62,7 +62,7 @@ namespace MarketingPageAcceptanceTests.Actions.Pages
 
         public void ErrorSectionDisplayed()
         {
-            wait.Until(s => s.FindElement(pages.Common.ErrorSection).Displayed);
+            wait.Until(s => s.FindElements(pages.Common.ErrorSection).Count == 1);
         }
 
         public void ErrorMessagesDisplayed(int numSections)


### PR DESCRIPTION
https://buyingcatalog.visualstudio.com/Buying%20Catalogue/_releaseProgress?_a=release-environment-logs&releaseId=2030&environmentId=5511
3 tests failed, all due to waiting on the error summary.
changed wait to use count instead of displayed