### PR TITLE
Update entrypoint to run all tests in single command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@nhs-digital-gp-it-futures/buying-catalogue-approvers
+*       @nhs-digital-gp-it-futures/buying-catalogue-approvers

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,11 +36,7 @@ if [ -n "${TEST_FILTER}" ]; then
   echo -e "\n Running '$cmd' \n"
   eval $cmd
 else
-  cmd="dotnet test out/MarketingPageAcceptanceTests.AuthorityTests.dll -v n $(setAdditionalArgs authority)"
-  echo -e "\n Running '$cmd' \n"
-  eval $cmd
-
-  cmd="dotnet test out/MarketingPageAcceptanceTests.SupplierTests.dll -v n $(setAdditionalArgs supplier)"
+  cmd="dotnet test out/MarketingPageAcceptanceTests.AuthorityTests.dll out/MarketingPageAcceptanceTests.SupplierTests.dll -v n $(setAdditionalArgs full)"
   echo -e "\n Running '$cmd' \n"
   eval $cmd
 fi


### PR DESCRIPTION
This change is due to a rare issue where an authority page test fails, but the rest of the suite passes the overall run is not failed. The change within the commit here should fail if any test fails, forcing a rerun of the job